### PR TITLE
fixed file descriptor leak

### DIFF
--- a/runbook/executor.go
+++ b/runbook/executor.go
@@ -51,6 +51,7 @@ func Execute(executablePath string, args, environmentVars []string, stdout, stde
 	cmd.Stderr = stderrBuff
 	if stderr != nil {
 		cmd.Stderr = io.MultiWriter(stderr, cmd.Stderr)
+		defer stderr.Close()
 	}
 	if stdout != nil {
 		cmd.Stdout = stdout


### PR DESCRIPTION
Fixes issue #14 the easy way, leveraging the fact that cmd.Run() waits until the process has finished, thus closing the Stderr logger manually.

A possibly better fix would be the following, I guess it's up to the PO to decide.
```
writer := bufio.NewWriter(outfile)
defer writer.Flush()              
                                  
if err = cmd.Start(); err != nil {
    /* handle the error */
}                                 
go io.Copy(writer, stdoutBuff)

if err = cmd.Wait(); err != nil {
    /* handle the error */
}    
```