### PR TITLE
Added 'dep init' to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ RUN chmod +x /usr/bin/dep
 ADD . $GOPATH/src/github.com/opsgenie/oec
 WORKDIR $GOPATH/src/github.com/opsgenie/oec/main
 RUN export GIT_COMMIT=$(git rev-list -1 HEAD) && \
+    dep init && \
     dep ensure -v && \
     CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -installsuffix cgo \
         -ldflags "-X main.OECCommitVersion=$GIT_COMMIT -X main.OECVersion=1.0.1" -o nocgo -o /oec .


### PR DESCRIPTION
Update Docker file to fix next issue:

```
# docker build . -t oec

Sending build context to Docker daemon  19.19MB
Step 1/12 : FROM golang:1.11.4 as builder
 ---> dd46c1256829
Step 2/12 : ADD https://github.com/golang/dep/releases/download/v0.5.0/dep-linux-amd64 /usr/bin/dep
Downloading [==================================================>]  8.718MB/8.718MB
 ---> Using cache
 ---> 76b16e35c574
Step 3/12 : RUN chmod +x /usr/bin/dep
 ---> Using cache
 ---> 6ffed70b185a
Step 4/12 : ADD . $GOPATH/src/github.com/opsgenie/oec
 ---> 4942bdf77388
Step 5/12 : WORKDIR $GOPATH/src/github.com/opsgenie/oec/main
 ---> Running in 3e867f6aff7e
Removing intermediate container 3e867f6aff7e
 ---> a1ec961e29c4
Step 6/12 : RUN export GIT_COMMIT=$(git rev-list -1 HEAD) &&     dep ensure -v &&     CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -installsuffix cgo         -ldflags "-X main.OECCommitVersion=$GIT_COMMIT -X main.OECVersion=1.0.1" -o nocgo -o /oec .
 ---> Running in 73904ba08985

could not find project Gopkg.toml, use dep init to initiate a manifest

The command '/bin/sh -c export GIT_COMMIT=$(git rev-list -1 HEAD) &&     dep ensure -v &&     CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -installsuffix cgo         -ldflags "-X main.OECCommitVersion=$GIT_COMMIT -X main.OECVersion=1.0.1" -o nocgo -o /oec .' returned a non-zero code: 1```